### PR TITLE
Make Flint And Steel a 100% chance to start fire

### DIFF
--- a/overrides/config/gregtech.cfg
+++ b/overrides/config/gregtech.cfg
@@ -352,7 +352,7 @@ general {
         # Default: 50
         # Min: 0
         # Max: 100
-        I:flintChanceToCreateFire=50
+        I:flintChanceToCreateFire=100
 
         # Setting this to true makes GTCEu ignore error and invalid recipes that would otherwise cause crash.
         # Default: true


### PR DESCRIPTION
Default CEu config is to give flint and steel a 50% to actually create a fire, which isn't necessary in a pack like this.