### PR TITLE
Update to Nomi Labs v0.14.5

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -725,7 +725,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 6335086,
+      "fileID": 6355103,
       "required": true
     },
     {


### PR DESCRIPTION
This PR updates labs to v0.14.5, fixing a formatting issue on certain BQu descriptions on Windows, as reported by @D-Alessian.