### PR TITLE
Allow Treated Wood for Coated Circuit Board

### DIFF
--- a/overrides/groovy/post/main/general/early/earlygame.groovy
+++ b/overrides/groovy/post/main/general/early/earlygame.groovy
@@ -169,12 +169,38 @@ mods.gregtech.extractor.recipeBuilder()
     .duration(80).EUt(VA[ULV])
     .buildAndRegister()
 
-// Coated Circuit Board
+/* Coated Circuit Board */
+
+// Coated Circuit Board, Normal (allows planks instead of forcing plates)
+crafting.shapedBuilder()
+    .output(metaitem('board.coated') * 3)
+    .shape('RRR', 'PPP', 'RRR')
+    .key('R', metaitem('rubber_drop'))
+    .key('P', ore('plankWood'))
+    .replace().register()
+
+// Coated Circuit Board from Treated Wood (2x Normal Wood)
+crafting.shapedBuilder()
+    .output(metaitem('board.coated') * 6)
+    .shape('RRR', 'PPP', 'RRR')
+    .key('R', metaitem('rubber_drop'))
+    .key('P', ore('plankTreatedWood'))
+    .register()
+
+// Coated Circuit Board Assembler
 mods.gregtech.assembler.recipeBuilder()
     .inputs(ore('plateWood'))
     .fluidInputs(fluid('glue') * 100)
     .circuitMeta(1)
-    .outputs(metaitem('board.coated'))
+    .outputs(metaitem('board.coated') * 2)
+    .duration(100).EUt(VA[ULV])
+    .buildAndRegister()
+
+mods.gregtech.assembler.recipeBuilder()
+    .inputs(ore('plateTreatedWood'))
+    .fluidInputs(fluid('glue') * 100)
+    .circuitMeta(1)
+    .outputs(metaitem('board.coated') * 4)
     .duration(100).EUt(VA[ULV])
     .buildAndRegister()
 

--- a/overrides/scripts/electronics.zs
+++ b/overrides/scripts/electronics.zs
@@ -209,15 +209,6 @@ chemical_reactor.recipeBuilder().inputs(<metaitem:board.coated>).fluidInputs([<l
 //	[<metaitem:wireGtSingleCopper>, <metaitem:wireGtSingleCopper>, <metaitem:wireGtSingleCopper>]
 //]);
 
-
-recipes.removeByRecipeName("gregtech:coated_board");
-recipes.removeByRecipeName("gregtech:coated_board_1x");
-recipes.addShaped(<metaitem:board.coated> * 3, [
-	[<metaitem:rubber_drop>, <metaitem:rubber_drop>, <metaitem:rubber_drop>],
-	[<ore:plankWood>, <ore:plankWood>, <ore:plankWood>],
-	[<metaitem:rubber_drop>, <metaitem:rubber_drop>, <metaitem:rubber_drop>]
-]);
-
 // topaz lens oredict
 <ore:craftingLensOrange>.add(<metaitem:lensTopaz>);
 


### PR DESCRIPTION
This PR allows using treated wood for the coated circuit board.

To fit this, the following changes have been made:
- New treated Wood Plank/Plate crafting recipe, 2x yield over normal wood
- Changed assembler recipe for Coated Circuit Board with 2x yield
- New treated Wood Plate assembler recipe, 1 plate + 100mb glue for 4 boards