### PR TITLE
Don't add nbt to newly crafted empty cap banks

### DIFF
--- a/overrides/scripts/JetpacksAndEnergyStorage.zs
+++ b/overrides/scripts/JetpacksAndEnergyStorage.zs
@@ -127,7 +127,10 @@ val sumCapacitorBankPower as IRecipeFunction = function(out, ins, cInfo) {
 		if (ins.right.tag.memberGet("enderio:energy")) {
 			energy += ins.right.tag.memberGet("enderio:energy");
 		}
-		return out.updateTag({"enderio:energy": energy});
+		if energy > 0 {
+			return out.updateTag({"enderio:energy": energy});
+		}
+		return out;
 	};
 
 // advanced capacitor bank


### PR DESCRIPTION
They worked, but clearing their nbt (with the shapeless recipe) would make them unstackable with fresh ones and unusable in AE2 autocrafting. This PR fixes that.