### PR TITLE
Fix Duplicated Words in Quest Checks Output

### DIFF
--- a/tools/tasks/helpers/questChecks/checksUtil.ts
+++ b/tools/tasks/helpers/questChecks/checksUtil.ts
@@ -22,7 +22,7 @@ export function logOrThrowProblem(
 ) {
 	if (data.shouldCheck)
 		throw new Error(
-			`${data.name} with ID ${data.id} at ${data.key} has ${describer}${describer ? ` ${describer}` : ""}
+			`${data.name} with ID ${data.id} at ${data.key} has ${describer ? ` ${describer}` : ""}
 			${problem}${conditionBefore ? ` ${conditionBefore}` : ""}!`,
 		);
 


### PR DESCRIPTION
This PR fixes duplicated words being present in certain cases when quest checks fail and throws an error.