### PR TITLE
Remove And Hide Materials -> Hide Materials

### DIFF
--- a/overrides/groovy/post/main/mode/normal/removeMaterials.groovy
+++ b/overrides/groovy/post/main/mode/normal/removeMaterials.groovy
@@ -1,7 +1,7 @@
 package post.main.mode.normal
 
 import static com.nomiceu.nomilabs.gregtech.material.registry.LabsMaterials.*
-import static com.nomiceu.nomilabs.groovy.GroovyHelpers.MaterialHelpers.removeAndHideMaterial
+import static com.nomiceu.nomilabs.groovy.GroovyHelpers.MaterialHelpers.hideMaterial
 
 import com.nomiceu.nomilabs.util.LabsModeHelper
 import gregtech.api.unification.material.Material
@@ -102,5 +102,5 @@ Material[] materials = [
 ]
 
 for (var material : materials) {
-    removeAndHideMaterial(material, false)
+    hideMaterial(material, false)
 }


### PR DESCRIPTION
This PR changes the hiding of materials in NM from `removeAndHide` to `hide`, saving on computation.

As far as I can see, these have no (crafting) recipes from external sources anyways, so this should have no effect.