### PR TITLE
Fix Test Commit CI

### DIFF
--- a/.github/workflows/testcommits.yml
+++ b/.github/workflows/testcommits.yml
@@ -25,6 +25,7 @@ jobs:
     # Only allow runs that have the CFCORE_API_TOKEN secret (e.g. we are in the main repo)
     if: needs.secretChecks.outputs.success == 'true'
     name: Test Commits
+    needs: secretChecks
     uses: ./.github/workflows/createchangelog.yml
     with:
       release_type: "Cutting Edge Build"


### PR DESCRIPTION
This PR fixes the test commit job not being a dependency of the secret checking job; causing the job to always be skipped.