### PR TITLE
Update CraftPresence and LoliASM

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -456,7 +456,7 @@
     },
     {
       "projectID": 297038,
-      "fileID": 6354438,
+      "fileID": 7146337,
       "required": true,
       "sides": [
         "client"
@@ -595,7 +595,7 @@
     },
     {
       "projectID": 460609,
-      "fileID": 6854259,
+      "fileID": 7267368,
       "required": true
     },
     {


### PR DESCRIPTION
This PR updates CraftPresence and LoliASM.

CraftPresence update was meant to be in #1453, supported by the UniLib update in that PR.