### PR TITLE
Properly Remove OreDicts from Project Red's Red Alloy

### DIFF
--- a/overrides/scripts/_oreDict.zs
+++ b/overrides/scripts/_oreDict.zs
@@ -714,6 +714,11 @@ var ingotsDisabled as IItemStack[][IOreDictEntry] = {
 		<projectred-core:resource_item:103>
 	],
 
+	#ingotRedAlloy
+	<ore:ingotRedAlloy> : [
+		<projectred-core:resource_item:103>
+	],
+
 	#ingotSignalum
 	<ore:ingotSignalum> : [
 		<thermalfoundation:material:165>


### PR DESCRIPTION
This PR properly removes oredict entries from Project Red's Red Alloy; as they were under `ingotRedAlloy`.