### PR TITLE
Update Labs, GrS, HEI

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -631,7 +631,7 @@
     },
     {
       "projectID": 557549,
-      "fileID": 7237286,
+      "fileID": 7340288,
       "required": true
     },
     {
@@ -681,7 +681,7 @@
     },
     {
       "projectID": 687577,
-      "fileID": 7092147,
+      "fileID": 7343465,
       "required": true
     },
     {
@@ -751,7 +751,7 @@
     },
     {
       "projectID": 932060,
-      "fileID": 7323565,
+      "fileID": 7349473,
       "required": true
     },
     {


### PR DESCRIPTION
This PR updates Nomi Labs, GrS and HEI.

- GrS update: fixes an issue with nbt matching, and implements special JEI reloads.
- HEI update: features better documentation in tooltips for autocrafting/bookmark groups, and fixes an issue relating to `/gs reload` and recipe bookmarks.
- Labs update: adds compat for GrS update.

This only affects nightly builds; it has no effect upon release build.