### PR TITLE
Allow Copying AdvRocketry Station ID Chips

### DIFF
--- a/overrides/groovy/post/main/mod/advancedRocketry.groovy
+++ b/overrides/groovy/post/main/mod/advancedRocketry.groovy
@@ -1,9 +1,35 @@
 package post.main.mod
 
+import static com.nomiceu.nomilabs.groovy.GroovyHelpers.TranslationHelpers.translatable
 import static gregtech.api.GTValues.*
 
+import com.cleanroommc.groovyscript.compat.vanilla.CraftingInfo
+import com.cleanroommc.groovyscript.compat.vanilla.CraftingRecipe.InputList
 import com.nomiceu.nomilabs.util.LabsModeHelper
 import net.minecraft.item.ItemStack
+import net.minecraft.nbt.NBTTagCompound
+import net.minecraftforge.common.util.Constants
+
+/* Space Station ID Chip Copy Recipe */
+var spaceStationChip = item('advancedrocketry:spacestationchip')
+var exampleNbt = [ UUID : 1 ]
+
+var sourceChip = spaceStationChip.copy()
+    .withNbt(exampleNbt) // Example only
+    .withNbtFilter { NBTTagCompound nbt ->
+        // NBT handling: not empty, contains UUID
+        !nbt.empty && nbt.hasKey('UUID', Constants.NBT.TAG_ANY_NUMERIC)
+    }.mark('source')
+    .reuse()
+
+crafting.shapelessBuilder()
+    .output(spaceStationChip.copy().withNbt(exampleNbt)) // Example only
+    .input(sourceChip, spaceStationChip.copy().whenNoNbt())
+    .recipeFunction { ItemStack output, InputList inputs, CraftingInfo info ->
+        output.tagCompound = inputs.findMarkedOrEmpty('source').tagCompound.copy()
+        return output
+    }.setOutputTooltip(translatable('nomiceu.tooltip.advancedrocketry.copy_station_id_chips'))
+    .register()
 
 /* Airtight Seal Recipes */
 // Industrial Rebreather Kit -> Airtight Seal

--- a/overrides/resources/modpack/lang/en_us.lang
+++ b/overrides/resources/modpack/lang/en_us.lang
@@ -44,6 +44,7 @@ nomiceu.tooltip.advancedrocketry.orbital_laser_drill.3=§7Consumes §e1,000,000�
 nomiceu.tooltip.advancedrocketry.orbital_laser_drill.4=§cExtremely finicky. Use at your own risk.§r
 nomiceu.tooltip.advancedrocketry.orbital_laser_drill.5=§cTry restarting your world if it isn't working.§r
 nomiceu.tooltip.advancedrocketry.basic_lens=§7A basic lens, used for the Orbital Laser Drill.§r
+nomiceu.tooltip.advancedrocketry.copy_station_id_chips=§dAllows you to copy Space Station ID Chips!§r
 
 # AE2 & NAE2
 nomiceu.tooltip.ae2.crafting_terminal_removal.1=§cThis item is being removed.§r


### PR DESCRIPTION
This PR adds a crafting recipe to allow players to copy station id chips.

This is heavily inspired by https://github.com/Nomifactory/Nomifactory/pull/1019.