### PR TITLE
HM: Remove Ench Books from Airtight Seal Recipes

### DIFF
--- a/overrides/groovy/post/main/mod/advancedRocketry.groovy
+++ b/overrides/groovy/post/main/mod/advancedRocketry.groovy
@@ -56,12 +56,6 @@ if (LabsModeHelper.normal) {
         .duration(500).EUt(VA[HV])
         .buildAndRegister()
 } else {
-    ItemStack respiration = item('minecraft:enchanted_book')
-    ItemStack holding = respiration.copy()
-
-    respiration.addEnchantment(enchantment('minecraft:respiration'), 1)
-    holding.addEnchantment(enchantment('cofhcore:holding'), 1)
-
     mods.extendedcrafting.table_crafting.shapedBuilder()
         .tierAdvanced()
         .output(item('nomilabs:industrial_rebreather_kit'))
@@ -77,11 +71,11 @@ if (LabsModeHelper.normal) {
         .key('C', metaitem('gas_collector.mv'))
         .key('T', ore('plateDoubleTitanium'))
         .key('P', item('advancedrocketry:pressuretank', 1)) // Normal Pressure Tank
-        .key('Z', respiration)
+        .key('Z', metaitem('buffer.mv'))
         .key('F', metaitem('fluid.regulator.ev'))
         .key('A', metaitem('pipeSmallFluidPolytetrafluoroethylene'))
         .key('D', ore('dustQuicklime'))
-        .key('Y', holding)
+        .key('Y', metaitem('super_tank.mv'))
         .key('B', metaitem('chemical_reactor.mv'))
         .key('X', metaitem('duct_tape'))
         .register()


### PR DESCRIPTION
This PR removes the enchantment books respiration and holding from the HM recipe for the industrial rebreather kit, instead replacing them with a MV buffer and a MV super tank respectively.

This has a primary and a secondary benefit:
Primary: the rebreather kit recipe, and thus the airtight seal recipe, can be properly handled by ae2, and won't accept any enchanted book
Secondary: exposes players to the GT buffers

Theming:
- Buffer: intended as a 'temporary storage' of oxygen below the gas collector, perhaps close to one's oxygen inflow, thus similar to the respiration enchantment
- Tank: acts as an additional storage for oxygen, similar to the holding enchantment

Balancing:
- Buffer and tank are MV to prevent excess titanium req, and to match the voltage of the gas collector and chemical reactor