### PR TITLE
Allow Flux Infused Shovel in Farming Station

### DIFF
--- a/overrides/groovy/post/main/mod/thermal.groovy
+++ b/overrides/groovy/post/main/mod/thermal.groovy
@@ -4,6 +4,9 @@ import com.nomiceu.nomilabs.groovy.SimpleIIngredient
 import com.nomiceu.nomilabs.util.ItemMeta
 import net.minecraft.item.ItemStack
 
+// Allow Flux Infused Shovel as a hoe in farming station
+ore('toolHoe').add(item('redstonearsenal:tool.shovel_flux'))
+
 /* Fix Tanks in JEI */
 // Remove All, then add them back
 mods.jei.ingredient.hide(item('thermalexpansion:tank'))


### PR DESCRIPTION
This PR allows thermal's 'Flux Infused Shovel' into farming stations. Note that they still need to be charged due to limits set by EnderIO specifically.

Fixes https://github.com/Nomi-CEu/Nomi-CEu/issues/1416.