### PR TITLE
Change Recipe Bookmark Group Color

### DIFF
--- a/overrides/config/jei/jei.cfg
+++ b/overrides/config/jei/jei.cfg
@@ -34,7 +34,7 @@ advanced {
     S:modNameFormat=blue italic
 
     # Color of the recipe bookmark group in RGBA format. [range: -2147483648 ~ 2147483647, default: -1627324672]
-    I:recipeBookmarkGroupColor=-1627324672
+    I:recipeBookmarkGroupColor=-6720579
 
     # Enable ultra low memory usage mode, can slow down searching by a lot however. [default: false]
     B:ultraLowMemoryUsage=false


### PR DESCRIPTION
This PR changes the recipe bookmark color from green (which may be misleading as some 'valid') to a Nomi-CEu magenta.

Example:
<img width="577" height="575" alt="image" src="https://github.com/user-attachments/assets/7dc3367c-9805-47c9-8b92-e0b37d5cd3f3" />
