### PR TITLE
Add Voltage to Tricorder for Clarity

### DIFF
--- a/overrides/resources/gregtech/lang/en_us.lang
+++ b/overrides/resources/gregtech/lang/en_us.lang
@@ -1,4 +1,4 @@
 gregtech.material.rhodium_plated_palladium=Rhodium Plated Lumium-Palladium
 gregtech.machine.muffler_hatch.lv.name=Muffler Hatch
-gregtech.metaitem.tricorder_scanner.name=Portable Scanner (MV)
+metaitem.tricorder_scanner.name=Portable Scanner (MV)
 item.gt.tool.screwdriver.name.name=GregTech Screwdriver


### PR DESCRIPTION
Adds (MV) to the name of the portable scanner to add clarity to what tier it is available in.