### PR TITLE
Fix Elevator and Slime Dying Recipes

### DIFF
--- a/overrides/groovy/post/classes/Common.groovy
+++ b/overrides/groovy/post/classes/Common.groovy
@@ -1,8 +1,12 @@
 package post.classes
 
 import com.cleanroommc.groovyscript.api.GroovyLog
+import com.cleanroommc.groovyscript.helper.ingredient.OreDictIngredient
 import com.google.common.base.Ascii
 import gregtech.api.GTValues
+import gregtech.api.unification.material.MarkerMaterial
+import gregtech.api.unification.material.MarkerMaterials
+import net.minecraft.item.EnumDyeColor
 import net.minecraft.item.ItemStack
 import org.apache.commons.lang3.tuple.Pair
 
@@ -15,6 +19,7 @@ class Common {
     private static List<Pair<String, ItemStack>> p2pVariantsCache = null
     private static List<ItemStack> eioGlassesCache = null
     private static List<Pair<Integer, String>> voltageNamesCache = null
+    private static List<ColorInfo> colorInfoCache = null
 
     /**
      * The GroovyScript logger.
@@ -93,6 +98,56 @@ class Common {
         }
 
         return eioGlassesCache
+    }
+
+    static List<ColorInfo> getColorInfo() {
+        if (colorInfoCache != null) return colorInfoCache
+
+        // We can't use marker materials' COLORS map, as it is broken for dark gray
+        colorInfoCache = []
+
+        for (int i = 0; i < EnumDyeColor.values().length; i++) {
+            var dye = EnumDyeColor.byMetadata(i)
+            var marker = MarkerMaterials.Color.VALUES[i]
+
+            colorInfoCache.add(new ColorInfo(dye, marker))
+        }
+
+        return colorInfoCache
+    }
+
+}
+
+class ColorInfo {
+
+    // CAREFUL: this may not be what you expect
+    // It matches (most) unlocalised items, but not ore dicts.
+    // Light blue = light_blue NOT lightBlue
+    // Light gray = silver NOT lightGray
+    private final String unlocalizedName
+
+    // Metadata of the relevant dye
+    private final int metadata
+
+    // Ore dict name of the dye
+    private final String oreDictName
+
+    ColorInfo(EnumDyeColor color, MarkerMaterial marker) {
+        unlocalizedName = color.name
+        metadata = color.metadata
+        oreDictName = "dye${marker.toCamelCaseString()}".toString()
+    }
+
+    String getUnlocalizedName() {
+        return unlocalizedName
+    }
+
+    int getMetadata() {
+        return metadata
+    }
+
+    OreDictIngredient getOreDict() {
+        return ore(oreDictName)
     }
 
 }

--- a/overrides/groovy/post/main/general/misc/qol/dyes.groovy
+++ b/overrides/groovy/post/main/general/misc/qol/dyes.groovy
@@ -2,9 +2,7 @@ package post.main.general.misc.qol
 
 import static post.classes.Common.*
 
-import com.cleanroommc.groovyscript.helper.ingredient.OreDictIngredient
 import com.nomiceu.nomilabs.groovy.ShapedConversionRecipe
-import net.minecraft.item.EnumDyeColor
 import net.minecraft.item.ItemStack
 
 // Backport MC 1.14 Dye Mechanics
@@ -43,41 +41,29 @@ ore('dyeWhite').remove(item('minecraft:dye', 15))
 ore('dye').remove(item('minecraft:dye', 15))
 addShapedConversionRecipe(metaitem('dye.white'), item('minecraft:dye', 15))
 
-var dyeHelperMap = [:]
-for (var color : EnumDyeColor.values()) {
-    dyeHelperMap.put(color.name, ore(combineCamelCase('dye', color.name)))
-}
-
 // Fix Elevator Redyeing
-for (var entry in dyeHelperMap.entrySet()) {
-    crafting.remove('elevatorid:redye_' + entry.key)
-    crafting.addShapeless(item('elevatorid:elevator_' + entry.key), [ore('blockElevator'), entry.value])
+for (var color in colorInfo) {
+    crafting.remove('elevatorid:redye_' + color.unlocalizedName)
+    crafting.addShapeless(item('elevatorid:elevator_' + color.unlocalizedName), [ore('blockElevator'), color.oreDict])
 }
 
 // Fix Slime Block Redyeing
-for (var color : EnumDyeColor.values()) {
-    var name = color.name
-    var meta = color.metadata
-    var oreIng = dyeHelperMap.get(name)
-    crafting.remove('darkutils:dyed_slime_block_' + name)
+for (var color in colorInfo) {
+    crafting.remove('darkutils:dyed_slime_block_' + color.unlocalizedName)
     crafting.shapedBuilder()
-        .output(item('darkutils:slime_dyed', meta) * 8)
+        .output(item('darkutils:slime_dyed', color.metadata) * 8)
         .matrix('SSS',
             'SDS',
             'SSS')
         .key('S', ore('blockSlime'))
-        .key('D', oreIng)
+        .key('D', color.oreDict)
         .register()
 }
 
 // Fix Satchel Redeying
-addOreDictToOreDict(ore('dye'), dyeHelperMap.values())
-
-static void addOreDictToOreDict(OreDictIngredient addTo, Collection<OreDictIngredient> from) {
-    for (var ing in from) {
-        for (var stack in ing) {
-            addTo.add(stack)
-        }
+for (var color in colorInfo) {
+    for (var stack in color.oreDict) {
+        ore('dye').add(stack)
     }
 }
 

--- a/overrides/groovy/post/main/general/misc/qol/nbtClearing.groovy
+++ b/overrides/groovy/post/main/general/misc/qol/nbtClearing.groovy
@@ -6,8 +6,8 @@ import static com.nomiceu.nomilabs.groovy.GroovyHelpers.TranslationHelpers.*
 import static com.nomiceu.nomilabs.groovy.NBTClearingRecipe.CAN_CLEAR_TOOLTIP
 import static com.nomiceu.nomilabs.groovy.NBTClearingRecipe.WARNING_TOOLTIP
 import static gregtech.common.metatileentities.MetaTileEntities.*
+import static post.classes.Common.*
 
-import net.minecraft.item.EnumDyeColor
 import net.minecraft.item.ItemStack
 
 // NBT Clearing Recipes
@@ -16,8 +16,8 @@ nbtClearingRecipe(item('minecraft:lava_bucket'), item('minecraft:bucket'))
 nbtClearingRecipe(item('forge:bucketfilled'), item('minecraft:bucket'))
 
 // Shulker Boxes
-for (var color : EnumDyeColor.values()) {
-    nbtClearingRecipe(item("minecraft:${color.name}_shulker_box"))
+for (var color : colorInfo) {
+    nbtClearingRecipe(item("minecraft:${color.unlocalizedName}_shulker_box"))
 }
 
 // GT Crates

--- a/overrides/groovy/post/main/general/misc/questbookOreDicts.groovy
+++ b/overrides/groovy/post/main/general/misc/questbookOreDicts.groovy
@@ -1,7 +1,8 @@
 package post.main.general.misc
 
+import static post.classes.Common.*
+
 import com.nomiceu.nomilabs.util.LabsModeHelper
-import net.minecraft.item.EnumDyeColor
 
 // Steam Boilers
 ore('questbookSteamSolidBoiler').add(item('gregtech:machine', 1))
@@ -35,8 +36,8 @@ ore('questbookConveyor').add(metaitem('ulv_covers:conveyor.module.ulv'))
 ore('questbookConveyor').add(metaitem('conveyor.module.lv'))
 
 // Chemical Dyes
-for (var color : EnumDyeColor.values()) {
-    ore('questbookChemicalDye').add(metaitem("dye.${color.name}"))
+for (var color : colorInfo) {
+    ore('questbookChemicalDye').add(metaitem("dye.${color.unlocalizedName}"))
 }
 
 // Fishers

--- a/overrides/groovy/post/main/mod/ae2stuff.groovy
+++ b/overrides/groovy/post/main/mod/ae2stuff.groovy
@@ -3,7 +3,6 @@ package post.main.mod
 import static post.classes.Common.*
 
 import net.minecraft.init.SoundEvents
-import net.minecraft.item.EnumDyeColor
 
 // Network Visualisation Tool
 // Not replacing the recipe; prevents breaking existing patterns
@@ -28,7 +27,7 @@ for (String type : ['ae2stuff:wireless', 'ae2stuff:wireless_hub']) {
 
     mods.chisel.carving.addVariation(type, item(type))
 
-    for (var color : EnumDyeColor.values()) {
+    for (var color : colorInfo) {
         int wirelessMeta = color.metadata + 1 // + 1 because 0 is fluix
 
         // Hides dyed variants from JEI
@@ -42,7 +41,7 @@ for (String type : ['ae2stuff:wireless', 'ae2stuff:wireless_hub']) {
                 'WDW',
                 'WWW')
             .key('W', item(type))
-            .key('D', ore(combineCamelCase('dye', color.name)))
+            .key('D', color.oreDict)
             .replace().register()
 
         // Add to the chisel group


### PR DESCRIPTION
This PR fixes elevator and slime dying recipes having missing dyes for light blue and light gray dyes.

Why did MC decide to use `silver` everywhere internally and then `lightGray` everywhere else? ...