### PR TITLE
Fix Pump Tooltips Overreporting Transfer Rate by 4x

### DIFF
--- a/overrides/groovy/post/main/general/misc/tooltips.groovy
+++ b/overrides/groovy/post/main/general/misc/tooltips.groovy
@@ -411,7 +411,7 @@ for (var material : GregTechAPI.materialManager.registeredMaterials) {
 // Pumps
 // Change Unit in Tooltips to L/s
 for (var tier : getVoltageNames(LV, UV)) {
-    long transferAmt = 1280 * (long) Math.pow(4, tier.key)
+    long transferAmt = 1280 * (long) Math.pow(4, tier.key - 1) // voltage - 1, as 1280 is for LV (index 1)
 
     String transferFmt = TextFormattingUtil.formatNumbers(transferAmt)
 


### PR DESCRIPTION
This PR fixes pump tooltips having a (max) transfer rate reported in JEI that was 4x the actual.

Reported by atramentis (discord).