### PR TITLE
Fix Piston Recipes not Accepting Rubber Wood

### DIFF
--- a/overrides/groovy/post/main/general/early/earlygame.groovy
+++ b/overrides/groovy/post/main/general/early/earlygame.groovy
@@ -3,6 +3,7 @@ package post.main.general.early
 import static com.nomiceu.nomilabs.groovy.GroovyHelpers.JEIHelpers.addRecipeInputTooltip
 import static com.nomiceu.nomilabs.groovy.GroovyHelpers.RecyclingHelpers.*
 import static com.nomiceu.nomilabs.groovy.GroovyHelpers.TranslationHelpers.translatable
+import static com.nomiceu.nomilabs.groovy.GroovyHelpers.GTRecipeHelpers.toGtInput
 import static gregtech.api.GTValues.*
 import static org.apache.commons.lang3.tuple.Pair.of
 
@@ -47,6 +48,13 @@ if (LabsModeHelper.expert) {
 } else {
     // Remove mc paper recipe, is useless with endercore's shapeless one
     crafting.remove('minecraft:paper')
+
+    // Fix piston recipes: in only NM, GT forgot to use oredict for planks
+    mods.gregtech.assembler.changeByOutput([item('minecraft:piston')], null)
+        .forEach { ChangeRecipeBuilder builder ->
+            builder.changeInput(1) { return toGtInput(ore('plankWood')) }
+                .replaceAndRegister()
+        }
 }
 
 // Compressed Coke Clay Recipe


### PR DESCRIPTION
This PR fixes the piston assembler recipes in normal mode, which only accepted any meta of wooden planks, but not anything in the oredict `plankWood`.

This, gameplay wise, basically only changes pistons to accept rubber wood.