### PR TITLE
Fix Inconsistent Recipe for ZPM 4A Dynamo Hatch

### DIFF
--- a/overrides/groovy/post/main/general/late/lategame.groovy
+++ b/overrides/groovy/post/main/general/late/lategame.groovy
@@ -19,6 +19,25 @@ mods.gregtech.fusion_reactor.changeByOutput(null, [fluid('plutonium')])
             .replaceAndRegister()
     }
 
+// ZPM 4A Dynamo Hatch
+// GT forgot to remove the transformer from its recipe, making it inconsistent
+// Keep the original recipe (but hidden) to avoid breaking patterns
+// Although the two recipes seem to conflict, patterns set to the original won't use the new one
+// (as its registered first and so will be checked first)
+// TODO remove the original recipe in 1.8; if not already done so by GT
+mods.gregtech.assembler.changeByOutput([metaitem('energy_hatch.output_4a.zpm')], null)
+    .forEach { ChangeRecipeBuilder builder ->
+        // Make original hidden
+        builder.copyOriginal()
+            .builder { recipe -> recipe.hidden() }
+            .replaceAndRegister()
+
+        // New recipe with no transformer (first input)
+        builder.copyOriginal()
+            .removeInputs(0)
+            .replaceAndRegister()
+    }
+
 // Omnium Implosion Compressor Recipes
 ImplosionRecipeBuilder builder = mods.gregtech.implosion_compressor.recipeBuilder()
     .inputs(item('extendedcrafting:singularity_ultimate'))


### PR DESCRIPTION
This PR fixes the zpm 4a dynamo hatch recipe including the transformer, making it inconsistent with all other 4A dynamo and energy hatch recipes.

The original recipe including the transformer has not been removed, only hidden, to not break existing patterns.

It is also important to note that this transformer didn't do anything to gate the 4A dynamo or similar; its only unique ingredient was YBCO, which only requires RTM, and is needed regardless in ZPM 16A hatches.

Fixes #1492 