### PR TITLE
Fix Dupe Glitch Involving Plastics

### DIFF
--- a/overrides/groovy/post/main/general/misc/qol/pulps.groovy
+++ b/overrides/groovy/post/main/general/misc/qol/pulps.groovy
@@ -4,6 +4,8 @@ import static gregtech.api.unification.material.Materials.*
 import static gregtech.api.unification.ore.OrePrefix.*
 
 import com.nomiceu.nomilabs.groovy.ChangeRecipeBuilder
+
+import gregtech.api.recipes.ingredients.GTRecipeInput
 import gregtech.api.recipes.ingredients.GTRecipeItemInput
 import gregtech.api.unification.OreDictUnifier
 
@@ -37,8 +39,8 @@ for (var material : materials) {
 
         mods.gregtech.extruder.changeByOutput([stack], null)
             .forEach { ChangeRecipeBuilder builder ->
-                builder.changeInput(0) {
-                    new GTRecipeItemInput(dust, it.amount)
+                builder.changeInput(0) { GTRecipeInput input ->
+                    new GTRecipeItemInput(dust, input.amount)
                 }.buildAndRegister()
             }
     }


### PR DESCRIPTION
Fixes #1506 

All pulps can be turned from 1 pulp to 1 block to 9 pulp and repeat to dupe.

Fixes by making the recipe 9 pulp for block.