### PR TITLE
Disable optimizeFMLRemapper to prevent startup crashes

### DIFF
--- a/overrides/config/loliasm.cfg
+++ b/overrides/config/loliasm.cfg
@@ -281,7 +281,7 @@ modfixes {
 
 remapper {
     # Optimizing Forge's Remapper for not storing redundant entries - <default: true>
-    B:optimizeFMLRemapper=true
+    B:optimizeFMLRemapper=false
 }
 
 


### PR DESCRIPTION
Enabling the optimizeFMLRemapper setting causes startup crashes in some cases. The exact conditions for this do not seem to have been identified anywhere, but I found multiple reports of this issue in various contexts, which I have linked below. For me Nomifactory CEu was crashing during startup roughly half of the time, but it has never crashed since I disabled this feature.

https://github.com/LoliKingdom/LoliASM/issues/277
https://github.com/embeddedt/VintageFix/issues/164
https://github.com/cabaletta/baritone/issues/3820
https://github.com/cabaletta/baritone/issues/3914