### PR TITLE
Pin 3rd Party Actions to Commit Hashes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,12 @@ updates:
       - "github-actions"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/tools"
+    labels:
+      - "dependencies"
+      - "auto-creation"
+      - "javascript"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
       - "github-actions"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/tools"
@@ -15,5 +18,9 @@ updates:
       - "dependencies"
       - "auto-creation"
       - "javascript"
+    open-pull-requests-limit: 10
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    labels:
+      - "dependencies"
+      - "auto-creation"
+      - "github-actions"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,16 @@ updates:
       - "github-actions"
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+    groups:
+      actions-breaking:
+        applies-to: version-updates
+        update-types:
+          - major
+      actions-safe-updates:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: "npm"
     directory: "/tools"
@@ -18,9 +25,13 @@ updates:
       - "dependencies"
       - "auto-creation"
       - "javascript"
-    open-pull-requests-limit: 10
     schedule:
       interval: "weekly"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+    groups:
+      npm-safe-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,11 +27,14 @@ updates:
       - "javascript"
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
     groups:
+      npm-breaking:
+        applies-to: version-updates
+        update-types:
+          - major
+
       npm-safe-updates:
         applies-to: version-updates
-        patterns:
-          - "*"
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -63,12 +63,12 @@ jobs:
         run: npm run gulp buildTypoCheck
 
       - name: Lang Typo Check
-        uses: crate-ci/typos@v1
+        uses: crate-ci/typos@02ea592e44b3a53c302f697cddca7641cd051c3d
         with:
           files: build/typo-check/
 
       - name: Other Misc Typo Check
-        uses: crate-ci/typos@v1
+        uses: crate-ci/typos@02ea592e44b3a53c302f697cddca7641cd051c3d
         with:
           files: .github/ README.md overrides/README.md
 
@@ -80,7 +80,7 @@ jobs:
     steps:
       - name: Secret Checks
         id: secretChecks
-        uses: Nomi-CEu/SecretChecker@v1.1.0
+        uses: Nomi-CEu/SecretChecker@9de55f1a6e04dfa7ead446328c0420bb0a748e81
         with:
           secrets: ${{ toJSON(secrets) }}
           check: CFCORE_API_TOKEN
@@ -138,7 +138,7 @@ jobs:
     steps:
       - name: Secret Checks
         id: secretChecks
-        uses: Nomi-CEu/SecretChecker@v1.1.0
+        uses: Nomi-CEu/SecretChecker@9de55f1a6e04dfa7ead446328c0420bb0a748e81
         with:
           secrets: ${{ toJSON(secrets) }}
           check: |
@@ -201,7 +201,7 @@ jobs:
 
       - name: Find Comment
         if: ${{ hashFiles('./build/modChanges.md') != '' }}
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -212,7 +212,7 @@ jobs:
 
       - name: Create or Update Comment
         if: ${{ hashFiles('./build/modChanges.md') != '' }}
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -63,12 +63,12 @@ jobs:
         run: npm run gulp buildTypoCheck
 
       - name: Lang Typo Check
-        uses: crate-ci/typos@02ea592e44b3a53c302f697cddca7641cd051c3d
+        uses: crate-ci/typos@02ea592e44b3a53c302f697cddca7641cd051c3d # v1.45.0
         with:
           files: build/typo-check/
 
       - name: Other Misc Typo Check
-        uses: crate-ci/typos@02ea592e44b3a53c302f697cddca7641cd051c3d
+        uses: crate-ci/typos@02ea592e44b3a53c302f697cddca7641cd051c3d # v1.45.0
         with:
           files: .github/ README.md overrides/README.md
 
@@ -80,7 +80,7 @@ jobs:
     steps:
       - name: Secret Checks
         id: secretChecks
-        uses: Nomi-CEu/SecretChecker@9de55f1a6e04dfa7ead446328c0420bb0a748e81
+        uses: Nomi-CEu/SecretChecker@9de55f1a6e04dfa7ead446328c0420bb0a748e81 # v1.1.0
         with:
           secrets: ${{ toJSON(secrets) }}
           check: CFCORE_API_TOKEN
@@ -138,7 +138,7 @@ jobs:
     steps:
       - name: Secret Checks
         id: secretChecks
-        uses: Nomi-CEu/SecretChecker@9de55f1a6e04dfa7ead446328c0420bb0a748e81
+        uses: Nomi-CEu/SecretChecker@9de55f1a6e04dfa7ead446328c0420bb0a748e81 # v1.1.0
         with:
           secrets: ${{ toJSON(secrets) }}
           check: |
@@ -201,18 +201,18 @@ jobs:
 
       - name: Find Comment
         if: ${{ hashFiles('./build/modChanges.md') != '' }}
-        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'nomi-ceu-management[bot]'
+          comment-author: "nomi-ceu-management[bot]"
           body-includes: |
             ## PR Mod Changes
             *This comment is automatically updated with PR changes (when the workflow runs).*
 
       - name: Create or Update Comment
         if: ${{ hashFiles('./build/modChanges.md') != '' }}
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/createchangelog.yml
+++ b/.github/workflows/createchangelog.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Commit and Push Changelog
         if: ${{ inputs.branch }}
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9
         id: "commit-template"
         with:
           commit_message: "Upload Changelogs for Release ${{ inputs.tag }}"

--- a/.github/workflows/createchangelog.yml
+++ b/.github/workflows/createchangelog.yml
@@ -10,12 +10,12 @@ on:
         description: Release Type
         type: choice
         required: true
-        default: 'Release'
+        default: "Release"
         options:
-          - 'Release'
-          - 'Beta Release'
-          - 'Alpha Release'
-          - 'Cutting Edge Build'
+          - "Release"
+          - "Beta Release"
+          - "Alpha Release"
+          - "Cutting Edge Build"
       compare_tag:
         description: Tag(s) to compare against. If not set, will use the tag before `Tag`. If specifying multiple, separate by commas. (Spaces allowed).
         required: false
@@ -105,10 +105,9 @@ jobs:
           COMPARE_TAG: ${{ inputs.compare_tag }}
           TEST_CHANGELOG: ${{ inputs.test }}
 
-
       - name: Commit and Push Changelog
         if: ${{ inputs.branch }}
-        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         id: "commit-template"
         with:
           commit_message: "Upload Changelogs for Release ${{ inputs.tag }}"

--- a/.github/workflows/forkprchecks.yml
+++ b/.github/workflows/forkprchecks.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Secret Checks
         id: secretChecks
-        uses: Nomi-CEu/SecretChecker@v1.1.0
+        uses: Nomi-CEu/SecretChecker@9de55f1a6e04dfa7ead446328c0420bb0a748e81
         with:
           secrets: ${{ toJSON(secrets) }}
           check: CFCORE_API_TOKEN
@@ -254,7 +254,7 @@ jobs:
     steps:
       - name: Secret Checks
         id: secretChecks
-        uses: Nomi-CEu/SecretChecker@v1.1.0
+        uses: Nomi-CEu/SecretChecker@9de55f1a6e04dfa7ead446328c0420bb0a748e81
         with:
           secrets: ${{ toJSON(secrets) }}
           check: |
@@ -310,7 +310,7 @@ jobs:
 
       - name: Find Comment
         if: ${{ hashFiles('./build/modChanges.md') != '' }}
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -321,7 +321,7 @@ jobs:
 
       - name: Create or Update Comment
         if: ${{ hashFiles('./build/modChanges.md') != '' }}
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/forkprchecks.yml
+++ b/.github/workflows/forkprchecks.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Secret Checks
         id: secretChecks
-        uses: Nomi-CEu/SecretChecker@9de55f1a6e04dfa7ead446328c0420bb0a748e81
+        uses: Nomi-CEu/SecretChecker@9de55f1a6e04dfa7ead446328c0420bb0a748e81 # v1.1.0
         with:
           secrets: ${{ toJSON(secrets) }}
           check: CFCORE_API_TOKEN
@@ -254,7 +254,7 @@ jobs:
     steps:
       - name: Secret Checks
         id: secretChecks
-        uses: Nomi-CEu/SecretChecker@9de55f1a6e04dfa7ead446328c0420bb0a748e81
+        uses: Nomi-CEu/SecretChecker@9de55f1a6e04dfa7ead446328c0420bb0a748e81 # v1.1.0
         with:
           secrets: ${{ toJSON(secrets) }}
           check: |
@@ -310,18 +310,18 @@ jobs:
 
       - name: Find Comment
         if: ${{ hashFiles('./build/modChanges.md') != '' }}
-        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'nomi-ceu-management[bot]'
+          comment-author: "nomi-ceu-management[bot]"
           body-includes: |
             ## PR Mod Changes
             *This comment is automatically updated with PR changes (when the workflow runs).*
 
       - name: Create or Update Comment
         if: ${{ hashFiles('./build/modChanges.md') != '' }}
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/releasecommit.yml
+++ b/.github/workflows/releasecommit.yml
@@ -105,7 +105,7 @@ jobs:
         run: npm run gulp updateFilesAll
 
       - name: Commit and Push Release Changes
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9
         id: commit-release
         if: ${{ !inputs.update_files }}
         with:
@@ -116,7 +116,7 @@ jobs:
           tagging_message: "${{ inputs.tag }}"
 
       - name: Commit and Push Update Changes
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9
         id: commit-update
         if: ${{ inputs.update_files }}
         with:

--- a/.github/workflows/releasecommit.yml
+++ b/.github/workflows/releasecommit.yml
@@ -11,14 +11,14 @@ on:
         type: string
         required: false
       release_type:
-        description: 'Release Type. Will be ignored if not a release.'
+        description: "Release Type. Will be ignored if not a release."
         type: choice
         required: false
-        default: 'Release'
+        default: "Release"
         options:
-          - 'Release'
-          - 'Beta Release'
-          - 'Alpha Release'
+          - "Release"
+          - "Beta Release"
+          - "Alpha Release"
       update_files:
         description: |
           Whether this commit is just to update files. version.txt will not be changed. This is used when the templates are changed, and the main files need to be updated.
@@ -36,7 +36,7 @@ on:
         type: string
         required: false
       release_type:
-        description: 'Release Type. Will be ignored if not a release.'
+        description: "Release Type. Will be ignored if not a release."
         type: string
         required: false
       update_files:
@@ -105,7 +105,7 @@ jobs:
         run: npm run gulp updateFilesAll
 
       - name: Commit and Push Release Changes
-        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         id: commit-release
         if: ${{ !inputs.update_files }}
         with:
@@ -116,7 +116,7 @@ jobs:
           tagging_message: "${{ inputs.tag }}"
 
       - name: Commit and Push Update Changes
-        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         id: commit-update
         if: ${{ inputs.update_files }}
         with:

--- a/.github/workflows/testbuildpack.yml
+++ b/.github/workflows/testbuildpack.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Secret Checks
         id: secretChecks
-        uses: Nomi-CEu/SecretChecker@v1.1.0
+        uses: Nomi-CEu/SecretChecker@9de55f1a6e04dfa7ead446328c0420bb0a748e81
         with:
           secrets: ${{ toJSON(secrets) }}
           check: CFCORE_API_TOKEN

--- a/.github/workflows/testbuildpack.yml
+++ b/.github/workflows/testbuildpack.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Secret Checks
         id: secretChecks
-        uses: Nomi-CEu/SecretChecker@9de55f1a6e04dfa7ead446328c0420bb0a748e81
+        uses: Nomi-CEu/SecretChecker@9de55f1a6e04dfa7ead446328c0420bb0a748e81 # v1.1.0
         with:
           secrets: ${{ toJSON(secrets) }}
           check: CFCORE_API_TOKEN

--- a/.github/workflows/testcommits.yml
+++ b/.github/workflows/testcommits.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Secret Checks
         id: secretChecks
-        uses: Nomi-CEu/SecretChecker@v1.1.0
+        uses: Nomi-CEu/SecretChecker@9de55f1a6e04dfa7ead446328c0420bb0a748e81
         with:
           secrets: ${{ toJSON(secrets) }}
           check: CFCORE_API_TOKEN

--- a/.github/workflows/testcommits.yml
+++ b/.github/workflows/testcommits.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Secret Checks
         id: secretChecks
-        uses: Nomi-CEu/SecretChecker@9de55f1a6e04dfa7ead446328c0420bb0a748e81
+        uses: Nomi-CEu/SecretChecker@9de55f1a6e04dfa7ead446328c0420bb0a748e81 # v1.1.0
         with:
           secrets: ${{ toJSON(secrets) }}
           check: CFCORE_API_TOKEN

--- a/.github/workflows/updateEnglishLang.yml
+++ b/.github/workflows/updateEnglishLang.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Secret Checks
         id: secretChecks
-        uses: Nomi-CEu/SecretChecker@v1.1.0
+        uses: Nomi-CEu/SecretChecker@9de55f1a6e04dfa7ead446328c0420bb0a748e81
         with:
           secrets: ${{ toJSON(secrets) }}
           check: |

--- a/.github/workflows/updateEnglishLang.yml
+++ b/.github/workflows/updateEnglishLang.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Secret Checks
         id: secretChecks
-        uses: Nomi-CEu/SecretChecker@9de55f1a6e04dfa7ead446328c0420bb0a748e81
+        uses: Nomi-CEu/SecretChecker@9de55f1a6e04dfa7ead446328c0420bb0a748e81 # v1.1.0
         with:
           secrets: ${{ toJSON(secrets) }}
           check: |

--- a/.github/workflows/updateLabs.yml
+++ b/.github/workflows/updateLabs.yml
@@ -54,7 +54,7 @@ jobs:
         run: npm run gulp updateLabs
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676
         with:
           token: ${{ steps.token.outputs.token }}
           commit-message: Update Nomi Labs to ${{ env.VER }}

--- a/.github/workflows/updateLabs.yml
+++ b/.github/workflows/updateLabs.yml
@@ -54,7 +54,7 @@ jobs:
         run: npm run gulp updateLabs
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           token: ${{ steps.token.outputs.token }}
           commit-message: Update Nomi Labs to ${{ env.VER }}


### PR DESCRIPTION
This PR pins all 3rd party actions to a commit hash. Version tags are mutable and thus, prone to supply-chain attacks if the actions ever get compromised. This happened recently with [trivy-action](https://github.com/aquasecurity/trivy-action), causing a [massive supply-chain attack](https://snyk.io/blog/poisoned-security-scanner-backdooring-litellm/). This affects:
- crate-ci/typos
- Nomi-CEu/SecretChecker
- peter-evans/create-or-update-comment
- peter-evans/create-pull-request
- peter-evans/find-comment
- stefanzweifel/git-auto-commit-action

To keep the actions up to date without pinning to a version tag, I added a dependabot config in `.github/dependabot.yml`. It would be useful to take a look at it following the [config references](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference), and give feedback. Some consideration I had:
- use the `allow` option and `ignore` option with `update-types`? Might want to ignore breaking changes for example. I think this is the most important one to consider, but I left it open for now because it's pretty opinionated as to which strategy exactly should be used. How this would work in practice can be found [here](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/manage-your-dependency-security/controlling-dependencies-updated)
- use the `groups` option to avoid opening 100 PRs every week, perhaps? Though if it's just for github-actions it should be fine
- also update npm packages? It will keep the existing security updates behavior, this would be for regular non security related updates. Not sure if it's useful and could create a lot of PR bloat.