### PR TITLE
Small Balancing Changes to Nano and Quantum Tier Circuits

### DIFF
--- a/overrides/groovy/post/main/general/mid/circuits.groovy
+++ b/overrides/groovy/post/main/general/mid/circuits.groovy
@@ -18,9 +18,29 @@ mods.gregtech.circuit_assembler.changeByOutput([metaitem('circuit.workstation')]
 // IV: Tier 2 (Nano Supercomputer)
 mods.gregtech.circuit_assembler.changeByOutput([metaitem('circuit.nano_computer')], null)
     .forEach { ChangeRecipeBuilder builder ->
-        builder.removeInputs(-1, -2)
+        builder.removeInputs(-1)
             .builder { RecipeBuilder recipe ->
-                recipe.inputs(ore('wireFineLumium') * 8, ore('wireFineTungstenSteel') * 16)
+                recipe.inputs(ore('wireFineTungstenSteel') * 16)
+            }.copyProperties(CleanroomProperty.instance)
+            .replaceAndRegister()
+    }
+
+// IV: Tier 3 (Quantumprocesor Assembly)
+mods.gregtech.circuit_assembler.changeByOutput([metaitem('circuit.quantum_assembly')], null)
+    .forEach { ChangeRecipeBuilder builder ->
+        builder.removeInputs(-1)
+            .builder { RecipeBuilder recipe ->
+                recipe.inputs(ore('wireFineLumium') * 16)
+            }.copyProperties(CleanroomProperty.instance)
+            .replaceAndRegister()
+    }
+
+// ZPM: Tier 1 (Quantumprocessor Mainframe)
+mods.gregtech.circuit_assembler.changeByOutput([metaitem('circuit.quantum_mainframe')], null)
+    .forEach { ChangeRecipeBuilder builder ->
+        builder.removeInputs(-1)
+            .builder { RecipeBuilder recipe ->
+                recipe.inputs(ore('wireGtSingleSignalum') * 48)
             }.copyProperties(CleanroomProperty.instance)
             .replaceAndRegister()
     }


### PR DESCRIPTION
This PR makes various changes to the balancing and gating of nano and quantum tier circuits. This was inspired by nano circuits seeming overly-gated, quantum circuits having very little gating, and further integration of lumium and signalum into the pack.

## Changes to IV Nano Gating
Previously, this circuit required Tungsten Steel and Lumium, gating it behind RTM-Alloy Coils, and Primal Mana, which now requires a substantial processing chain in HM.

This has been changed to no longer require Lumium, and only Tungsten Steel. 16 RAM has been added to the recipe, which is included in the base recipe from GTCEu; to fill in the final spot and to act as a more obvious sign that the recipe has changed to players.

Rather than reverting back to electrum, tungstensteel has been used instead, still keeping the RTM Alloy coil gate, which does add some depth to this.

Note that there still exist other gates to IV Circuit Assembler anyways, including: quantum star, graphene, SBR/SiR, Iridium, and more.

## Changes to Quantum Gating
Lumium and Signalum have been added to quantum circuits, with the IV circuit having lumium (replacing platinum), and the ZPM circuit having signalum (replacing annealed copper). This integrates Lumium and Signalum back into circuit progression, as apart from the previous lumium gate for IV nanos, lumium does not feature elsewhere in circuits, and signalum does not currently feature at all.

This also means that quantum circuits are also now gated by Primal Mana, in addition to indium (which is an optional gate regardless). As lumium and signalum are in circuits, this may further encourage players to passive lumium (and to a lesser extent, signalum).

Note that this has been applied to the IV rather than the EV circuits, as EV circuits have SoC recipes that may be passived and could lead to more confusion for players. This has been applied to ZPM rather than LuV to preserve the consumption of platinum in quantum circuits, serving as a check for platline (or similar).

## Discussion Notes
Original legacy recipes have not been kept; players should transition their patterns. Is this valid given the change is intended for balancing purposes, and make circuits more expensive in some cases?

Should we increase the amount of platinum wire consumed in LuV quantum circs? Should we add lumium in for the EV instead of the IV quantum circ?

Should the RTM-Alloy Coil gate be kept for IV nanos? We could also alternatively move it to LuV nanos, or completely remove it (keeping electrum fine wire instead).

Consideration for 1.8: further integrate signalum and enderium beyond a few circuits, microminers and superconductors. Something similar to lumium's use in LuV hulls for example?

<hr>

@D-Alessian: review requested for code checks and balancing checks. @doniascion: Review requested for balancing advice, if you are available.