### PR TITLE
Update GroovyScript to 1.4.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ tools/node_modules
 *iml
 /overrides/groovy/assets/
 /overrides/groovy/lib/
+/overrides/groovy/sideOnlyGenerated.json
 
 **/.idea/
 **/.idea_modules/

--- a/manifest.json
+++ b/manifest.json
@@ -681,7 +681,7 @@
     },
     {
       "projectID": 687577,
-      "fileID": 7343465,
+      "fileID": 7925117,
       "required": true
     },
     {


### PR DESCRIPTION
This PR updates GroovyScript to v1.4.3, fixing a (potential?) GroovyScript crash with higher java versions. The new auto-generated file by GroovyScript has been added to the gitignore.