### PR TITLE
Changes for Molten Fluids

### DIFF
--- a/overrides/groovy/post/main/general/late/lategame.groovy
+++ b/overrides/groovy/post/main/general/late/lategame.groovy
@@ -1,5 +1,7 @@
 package post.main.general.late
 
+import cofh.thermalexpansion.util.managers.machine.CompactorManager
+
 import static com.nomiceu.nomilabs.groovy.GroovyHelpers.RecyclingHelpers.*
 import static gregtech.api.GTValues.*
 
@@ -109,6 +111,79 @@ createRecipe(metaitem('charger.uhv'), [
     [metaitem('wireGtQuadrupleEuropium'), metaitem('hull.uhv'), metaitem('wireGtQuadrupleEuropium')],
     [metaitem('cableGtSingleEuropium'), ore('circuitUhv'), metaitem('cableGtSingleEuropium')],
 ])
+
+// Empowered Crystals
+var empoweredNames = [
+    'restonia',
+    'palis',
+    'diamatine',
+    'void',
+    'emeradic',
+    'enori',
+]
+
+empoweredNames.eachWithIndex { String empowered, int idx ->
+    var crystal = item('actuallyadditions:item_crystal_empowered', idx)
+    var block = item('actuallyadditions:block_crystal_empowered', idx)
+    var liquid = fluid("moltenempowered${empowered}")
+
+    // Crystal & Blocks -> Liquid
+    mods.gregtech.extractor.recipeBuilder()
+        .inputs(crystal * 1)
+        .fluidOutputs(liquid * L)
+        .duration(40).EUt(VA[LV])
+        .buildAndRegister()
+
+    mods.gregtech.extractor.recipeBuilder()
+        .inputs(block * 1)
+        .fluidOutputs(liquid * (L * 9))
+        .duration(200).EUt(VA[LV])
+        .buildAndRegister()
+
+    // Liquid -> Crystal & Blocks
+    mods.gregtech.fluid_solidifier.recipeBuilder()
+        .fluidInputs(liquid * L)
+        .notConsumable(metaitem('shape.mold.ball'))
+        .outputs(crystal * 1)
+        .duration(80).EUt(VA[LV])
+        .buildAndRegister()
+
+    mods.gregtech.fluid_solidifier.recipeBuilder()
+        .fluidInputs(liquid * (L * 9))
+        .notConsumable(metaitem('shape.mold.block'))
+        .outputs(block * 1)
+        .duration(400).EUt(VA[LV])
+        .buildAndRegister()
+
+    // Liquid -> Gear
+    mods.gregtech.fluid_solidifier.recipeBuilder()
+        .fluidInputs(liquid * (L * 4))
+        .notConsumable(metaitem('shape.mold.gear'))
+        .outputs(item("moreplates:empowered_${empowered}_gear"))
+        .duration(200).EUt(VA[LV])
+        .buildAndRegister()
+
+    // Gearworking Die -> Gear
+    mods.thermal.compactor.recipeBuilder()
+        .input(crystal * 4)
+        .output(item("moreplates:empowered_${empowered}_gear"))
+        .mode(CompactorManager.Mode.GEAR)
+        .register()
+}
+
+// Dark Soularium: Ingot <-> Liquid
+mods.gregtech.extractor.recipeBuilder()
+    .inputs(item('simplyjetpacks:metaitemmods', 3))
+    .fluidOutputs(fluid('moltendarksoularium') * L)
+    .duration(20).EUt(VA[LV])
+    .buildAndRegister()
+
+mods.gregtech.fluid_solidifier.recipeBuilder()
+    .fluidInputs(fluid('moltendarksoularium') * L)
+    .notConsumable(metaitem('shape.mold.ingot'))
+    .outputs(item('simplyjetpacks:metaitemmods', 3))
+    .duration(40).EUt(VA[LV])
+    .buildAndRegister()
 
 // HM Ore Drilling Plants
 if (LabsModeHelper.expert) {

--- a/overrides/groovy/post/main/general/late/lategame.groovy
+++ b/overrides/groovy/post/main/general/late/lategame.groovy
@@ -1,10 +1,9 @@
 package post.main.general.late
 
-import cofh.thermalexpansion.util.managers.machine.CompactorManager
-
 import static com.nomiceu.nomilabs.groovy.GroovyHelpers.RecyclingHelpers.*
 import static gregtech.api.GTValues.*
 
+import cofh.thermalexpansion.util.managers.machine.CompactorManager
 import com.nomiceu.nomilabs.groovy.ChangeRecipeBuilder
 import com.nomiceu.nomilabs.util.LabsModeHelper
 import gregtech.api.recipes.builders.ImplosionRecipeBuilder

--- a/overrides/groovy/post/main/general/misc/content/blastFurnace.groovy
+++ b/overrides/groovy/post/main/general/misc/content/blastFurnace.groovy
@@ -17,7 +17,7 @@ mods.gregtech.alloy_blast_smelter.changeByOutput(null, [fluid('molten.lumium')])
             .changeEachFluidOutput { fluid -> fluid * (L * 4) }
             .copyProperties(TemperatureProperty.instance)
             .replaceAndRegister()
-        }
+    }
 
 // Signalum
 mods.gregtech.alloy_blast_smelter.changeByOutput(null, [fluid('molten.signalum')])
@@ -30,7 +30,7 @@ mods.gregtech.alloy_blast_smelter.changeByOutput(null, [fluid('molten.signalum')
             .changeEachFluidOutput { fluid -> fluid * (L * 4) }
             .copyProperties(TemperatureProperty.instance)
             .replaceAndRegister()
-        }
+    }
 
 // Enderium
 mods.gregtech.alloy_blast_smelter.changeByOutput(null, [fluid('molten.enderium')])
@@ -43,7 +43,7 @@ mods.gregtech.alloy_blast_smelter.changeByOutput(null, [fluid('molten.enderium')
             .changeEachFluidOutput { fluid -> fluid * (L * 4) }
             .copyProperties(TemperatureProperty.instance)
             .replaceAndRegister()
-        }
+    }
 
 // Fluxed Electrum
 mods.gregtech.alloy_blast_smelter.changeByOutput(null, [fluid('electrum_flux')])
@@ -55,4 +55,4 @@ mods.gregtech.alloy_blast_smelter.changeByOutput(null, [fluid('electrum_flux')])
             .changeEachFluidOutput { fluid -> fluid * (L * 9) }
             .copyProperties(TemperatureProperty.instance)
             .replaceAndRegister()
-        }
+    }

--- a/overrides/groovy/post/main/general/misc/content/materialChanges.groovy
+++ b/overrides/groovy/post/main/general/misc/content/materialChanges.groovy
@@ -52,7 +52,7 @@ mods.gregtech.alloy_blast_smelter.changeByOutput(null, [fluid('black_steel')])
         }.changeCircuitMeta { meta -> meta } // Copy Circuit
             .changeEachFluidOutput { FluidStack fluid -> return fluid * (L * 9) }
             .replaceAndRegister()
-        }
+    }
 
 /* Change Mixer Recipes */
 mods.gregtech.mixer.removeByOutput([metaitem('dustBlackSteel')], null)

--- a/overrides/groovy/post/main/general/misc/deprecation.groovy
+++ b/overrides/groovy/post/main/general/misc/deprecation.groovy
@@ -113,7 +113,7 @@ mods.gregtech.arc_furnace.changeByOutput([metaitem('nomilabs:ingotInfinity')], n
             return new GTRecipeOreInput(OreDictUnifier.getOreDictionaryNames(input.inputStacks[0]).first())
         }.changeEachOutput { out -> item('avaritia:resource', 6) * out.count }
             .replaceAndRegister()
-        }
+    }
 
 for (var map : [COMPRESSOR_RECIPES, ALLOY_SMELTER_RECIPES]) {
     map.virtualized.changeByOutput([metaitem('nomilabs:ingotInfinity')], null)

--- a/overrides/resources/nuclearcraft/lang/en_us.lang
+++ b/overrides/resources/nuclearcraft/lang/en_us.lang
@@ -1,2 +1,31 @@
 # line 1360 of jar file
 item.nuclearcraft.thorium._232.name=Prepared Thorium-232
+
+# Molten -> Liquid
+# Isn't performed for all NuclearCraft fluids; just ones visible in JEI
+tile.nuclearcraft.fluid_quartz.name=Liquid Quartz
+fluid.quartz=Liquid Quartz
+
+tile.nuclearcraft.fluid_lapis.name=Liquid Lapis
+fluid.lapis=Liquid Lapis
+
+tile.nuclearcraft.fluid_diamond.name=Liquid Diamond
+fluid.diamond=Liquid Diamond
+
+tile.nuclearcraft.fluid_emerald.name=Liquid Emerald
+fluid.emerald=Liquid Emerald
+
+tile.nuclearcraft.fluid_unsweetened_chocolate.name=Liquid Unsweetened Chocolate
+fluid.unsweetened_chocolate=Liquid Unsweetened Chocolate
+
+tile.nuclearcraft.fluid_dark_chocolate.name=Liquid Dark Chocolate
+fluid.dark_chocolate=Liquid Dark Chocolate
+
+tile.nuclearcraft.fluid_milk_chocolate.name=Liquid Milk Chocolate
+fluid.milk_chocolate=Liquid Milk Chocolate
+
+tile.nuclearcraft.fluid_sugar.name=Liquid Sugar
+fluid.sugar=Liquid Sugar
+
+tile.nuclearcraft.fluid_gelatin.name=Liquid Gelatin
+fluid.gelatin=Liquid Gelatin

--- a/overrides/scripts/_oreDict.zs
+++ b/overrides/scripts/_oreDict.zs
@@ -2389,40 +2389,6 @@ mods.jei.JEI.removeAndHide(<betterquesting:guide_book>);
 //fluidextractor.recipeBuilder().inputs(<minecraft:nether_star>).fluidOutputs([<liquid:nether_star> * 144]).duration(40).EUt(30).buildAndRegister();
 //fluidextractor.recipeBuilder().inputs(<metaitem:blockNetherStar>).fluidOutputs([<liquid:nether_star> * 1296]).duration(360).EUt(30).buildAndRegister();
 
-//Molten Empowered Restonia
-solidifier.recipeBuilder().fluidInputs(<liquid:moltenempoweredrestonia> * 1296).notConsumable(<metaitem:shape.mold.block>).outputs([<actuallyadditions:block_crystal_empowered>]).duration(400).EUt(30).buildAndRegister();
-solidifier.recipeBuilder().fluidInputs(<liquid:moltenempoweredrestonia> * 576).notConsumable(<metaitem:shape.mold.gear>).outputs([<moreplates:empowered_restonia_gear>]).duration(200).EUt(30).buildAndRegister();
-fluidextractor.recipeBuilder().inputs(<actuallyadditions:block_crystal_empowered>).fluidOutputs([<liquid:moltenempoweredrestonia> * 1296]).duration(200).EUt(30).buildAndRegister();
-
-//Molten Empowered Palis
-solidifier.recipeBuilder().fluidInputs(<liquid:moltenempoweredpalis> * 1296).notConsumable(<metaitem:shape.mold.block>).outputs([<actuallyadditions:block_crystal_empowered:1>]).duration(400).EUt(30).buildAndRegister();
-solidifier.recipeBuilder().fluidInputs(<liquid:moltenempoweredpalis> * 576).notConsumable(<metaitem:shape.mold.gear>).outputs([<moreplates:empowered_palis_gear>]).duration(200).EUt(30).buildAndRegister();
-fluidextractor.recipeBuilder().inputs(<actuallyadditions:block_crystal_empowered:1>).fluidOutputs([<liquid:moltenempoweredpalis> * 1296]).duration(200).EUt(30).buildAndRegister();
-
-//Molten Empowered Enori
-solidifier.recipeBuilder().fluidInputs(<liquid:moltenempoweredenori> * 1296).notConsumable(<metaitem:shape.mold.block>).outputs([<actuallyadditions:block_crystal_empowered:5>]).duration(400).EUt(30).buildAndRegister();
-solidifier.recipeBuilder().fluidInputs(<liquid:moltenempoweredenori> * 576).notConsumable(<metaitem:shape.mold.gear>).outputs([<moreplates:empowered_enori_gear>]).duration(200).EUt(30).buildAndRegister();
-fluidextractor.recipeBuilder().inputs(<actuallyadditions:block_crystal_empowered:5>).fluidOutputs([<liquid:moltenempoweredenori> * 1296]).duration(200).EUt(30).buildAndRegister();
-
-//Molten Empowered Diamatine
-solidifier.recipeBuilder().fluidInputs(<liquid:moltenempowereddiamatine> * 1296).notConsumable(<metaitem:shape.mold.block>).outputs([<actuallyadditions:block_crystal_empowered:2>]).duration(400).EUt(30).buildAndRegister();
-solidifier.recipeBuilder().fluidInputs(<liquid:moltenempowereddiamatine> * 576).notConsumable(<metaitem:shape.mold.gear>).outputs([<moreplates:empowered_diamatine_gear>]).duration(200).EUt(30).buildAndRegister();
-fluidextractor.recipeBuilder().inputs(<actuallyadditions:block_crystal_empowered:2>).fluidOutputs([<liquid:moltenempowereddiamatine> * 1296]).duration(200).EUt(30).buildAndRegister();
-
-//Molten Empowered Emeradic
-solidifier.recipeBuilder().fluidInputs(<liquid:moltenempoweredemeradic> * 1296).notConsumable(<metaitem:shape.mold.block>).outputs([<actuallyadditions:block_crystal_empowered:4>]).duration(400).EUt(30).buildAndRegister();
-solidifier.recipeBuilder().fluidInputs(<liquid:moltenempoweredemeradic> * 576).notConsumable(<metaitem:shape.mold.gear>).outputs([<moreplates:empowered_emeradic_gear>]).duration(200).EUt(30).buildAndRegister();
-fluidextractor.recipeBuilder().inputs(<actuallyadditions:block_crystal_empowered:4>).fluidOutputs([<liquid:moltenempoweredemeradic> * 1296]).duration(200).EUt(30).buildAndRegister();
-
-//Molten Empowered Void
-solidifier.recipeBuilder().fluidInputs(<liquid:moltenempoweredvoid> * 1296).notConsumable(<metaitem:shape.mold.block>).outputs([<actuallyadditions:block_crystal_empowered:3>]).duration(400).EUt(30).buildAndRegister();
-solidifier.recipeBuilder().fluidInputs(<liquid:moltenempoweredvoid> * 576).notConsumable(<metaitem:shape.mold.gear>).outputs([<moreplates:empowered_void_gear>]).duration(200).EUt(30).buildAndRegister();
-fluidextractor.recipeBuilder().inputs(<actuallyadditions:block_crystal_empowered:3>).fluidOutputs([<liquid:moltenempoweredvoid> * 1296]).duration(200).EUt(30).buildAndRegister();
-
-//Molten Dark Soularium
-solidifier.recipeBuilder().fluidInputs(<liquid:moltendarksoularium> * 144).notConsumable(<metaitem:shape.mold.ingot>).outputs([<simplyjetpacks:metaitemmods:3>]).duration(40).EUt(30).buildAndRegister();
-fluidextractor.recipeBuilder().inputs(<simplyjetpacks:metaitemmods:3>).fluidOutputs([<liquid:moltendarksoularium> * 144]).duration(20).EUt(30).buildAndRegister();
-
 //Molten Soularium
 //solidifier.recipeBuilder().fluidInputs(<liquid:moltensoularium> * 1296).notConsumable(<metaitem:shape.mold.block>).outputs([<enderio:block_alloy:7>]).duration(400).EUt(30).buildAndRegister();
 //solidifier.recipeBuilder().fluidInputs(<liquid:moltensoularium> * 144).notConsumable(<metaitem:shape.mold.ingot>).outputs([<enderio:item_alloy_ingot:7>]).duration(40).EUt(30).buildAndRegister();


### PR DESCRIPTION
This PR makes two changes for molten fluids:

1. Renames all non-gcym vacuum freezer needed fluids from Molten -> Liquid (in NC, other changes done in Nomi Labs). Fixes #1508 
2. Allows melting individual empowered crystals in the extractor, and adds a gearworking die recipe from empowered crystals to gears. Fixes #1503