### PR TITLE
Fix AE2 Blocking Mode with Gemstone Lenses

### DIFF
--- a/overrides/config/AppliedEnergistics2/AppliedEnergistics2.cfg
+++ b/overrides/config/AppliedEnergistics2/AppliedEnergistics2.cfg
@@ -74,6 +74,14 @@ blockingmode {
         gregtech:shape.extruder.rod_long
         gregtech:shape.extruder.rotor
         gregtech:lensGlass
+        gregtech:lensBlueTopaz
+        gregtech:lensDiamond
+        gregtech:lensEmerald
+        gregtech:lensRuby
+        gregtech:lensSapphire
+        gregtech:lensTopaz
+        gregtech:lensEnderPearl
+        gregtech:lensNetherStar
         gregtech:glass_lens.orange
         gregtech:glass_lens.magenta
         gregtech:glass_lens.light_blue


### PR DESCRIPTION
Updates ae2 config to make gem lenses behave the same as glass or colored lenses.