### PR TITLE
Fix Game Launch Crashes on Some Systems due to Large Textures

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -716,7 +716,7 @@
     },
     {
       "projectID": 871198,
-      "fileID": 6609247,
+      "fileID": 7958801,
       "required": true
     },
     {


### PR DESCRIPTION
VintageFix preventing the game from launching (at least it was crashing on Linux for me with AMD's open source drivers ver 26.1.3). Issue with large texture support


This is fixed by VintageFix [741e02a](https://github.com/embeddedt/VintageFix/commit/741e02a062e8518d3dcc22f4d34e2becf4ec9609) (present in v0.7)